### PR TITLE
Fix: Update readme to remove config ref

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # homeassistant
 
-This repository contains blueprints for managing heater system, and parts of configuration yaml files
+This repository contains blueprints (for managing heater system for now)
 
 ## Principle
 


### PR DESCRIPTION
Because config is stored elsewhere, we don't have to ref it here