### PR TITLE
Fix: Need to recompute setpoint on winter switch

### DIFF
--- a/heater_request_compute.yaml
+++ b/heater_request_compute.yaml
@@ -43,6 +43,8 @@ trigger:
   entity_id: !input current_temp
 - platform: state
   entity_id: !input selected_temp
+- platform: state
+  entity_id: !input winter_mode_boolean
 
 condition:
   - condition: state


### PR DESCRIPTION
If winter switch is turned on, we need to recompute setpoint