### PR TITLE
Fix: Use queued mode for setpoint computing and trigger on winter

### DIFF
--- a/heater_setpoint_compute.yaml
+++ b/heater_setpoint_compute.yaml
@@ -45,7 +45,7 @@ blueprint:
         entity:
           domain: input_boolean
 
-mode: single
+mode: queued
 max_exceeded: silent
 
 variables:
@@ -62,6 +62,8 @@ trigger:
   entity_id: !input schedule
 - platform: state
   entity_id: !input manual_boolean
+- platform: state
+  entity_id: !input winter_mode_boolean
 
 condition:
   - condition: state

--- a/heater_switch_mode.yaml
+++ b/heater_switch_mode.yaml
@@ -30,7 +30,7 @@ blueprint:
         entity:
           domain: input_boolean
 
-mode: single
+mode: queued
 max_exceeded: silent
 
 variables:
@@ -44,6 +44,8 @@ trigger:
   entity_id: !input climate_valve
   attribute: preset_mode
   to: auto
+- platform: state
+  entity_id: !input winter_mode_boolean
 
 condition:
   - condition: state


### PR DESCRIPTION
* Allow queued executions for setpoint computing
* Also for switching mode (manual/auto/etc)
* Use winter mode as trigger