### PR TITLE
Fix: Allow winter_mode trigger to work

### DIFF
--- a/heater_one_need.yaml
+++ b/heater_one_need.yaml
@@ -30,10 +30,10 @@ trigger:
 - platform: state
   entity_id: !input winter_mode_boolean
 
-condition:
-  - condition: state
-    entity_id: !input winter_mode_boolean
-    state: 'on'
+# condition:
+#   - condition: state
+#     entity_id: !input winter_mode_boolean
+#     state: 'on'
 
 action:
 - choose:


### PR DESCRIPTION
Remove the winter_mode = on condition, to allow to stop heater system when we leave the winter !