### PR TITLE
Fix: Don't start heater when one room is Both

### DIFF
--- a/heater_one_need.yaml
+++ b/heater_one_need.yaml
@@ -71,6 +71,14 @@ action:
       - condition: state
         entity_id: !input request_heater
         state: 'off'
+    # Et aucun n'est en Both...
+    - condition: and
+      conditions:
+        - condition: not
+          conditions:
+          - condition: state
+            entity_id: !input room_link_select
+            state: 'Both'
     sequence:
     - service: switch.turn_on
       data: {}


### PR DESCRIPTION
Real condition is:
  not (all rooms are off)
  and (all links are not Both)

This fixes https://github.com/francois09/inventories/issues/284