### PR TITLE
Fix: Unlock valve only if was locked

### DIFF
--- a/heater_room_link.yaml
+++ b/heater_room_link.yaml
@@ -91,14 +91,19 @@ action:
       entity_id: !input outside_aperture_sensor
       state: 'on'
     sequence:
-    - service: lock.unlock
-      data: {}
-      target:
-        entity_id: !input valve_child_lock
-    - service: climate.turn_on
-      data: {}
-      target:
-        entity_id: !input climate_valve
+    - if:
+      - condition: state
+        entity_id: !input room_link_select
+        state: Outside
+      then:
+      - service: lock.unlock
+        data: {}
+        target:
+          entity_id: !input valve_child_lock
+      - service: climate.turn_on
+        data: {}
+        target:
+          entity_id: !input climate_valve
     - service: input_select.select_option
       data:
         option: 'Both'
@@ -147,14 +152,19 @@ action:
       entity_id: !input outside_aperture_sensor
       state: 'off'
     sequence:
-    - service: lock.unlock
-      data: {}
-      target:
-        entity_id: !input valve_child_lock
-    - service: climate.turn_on
-      data: {}
-      target:
-        entity_id: !input climate_valve
+    - if:
+      - condition: state
+        entity_id: !input room_link_select
+        state: Outside
+      then:
+      - service: lock.unlock
+        data: {}
+        target:
+          entity_id: !input valve_child_lock
+      - service: climate.turn_on
+        data: {}
+        target:
+          entity_id: !input climate_valve
     - service: input_select.select_option
       data:
         option: 'Inside'
@@ -173,14 +183,19 @@ action:
       entity_id: !input outside_aperture_sensor
       state: 'off'
     sequence:
-    - service: lock.unlock
-      data: {}
-      target:
-        entity_id: !input valve_child_lock
-    - service: climate.turn_on
-      data: {}
-      target:
-        entity_id: !input climate_valve
+    - if:
+      - condition: state
+        entity_id: !input room_link_select
+        state: Outside
+      then:
+      - service: lock.unlock
+        data: {}
+        target:
+          entity_id: !input valve_child_lock
+      - service: climate.turn_on
+        data: {}
+        target:
+          entity_id: !input climate_valve
     - service: input_select.select_option
       data:
         option: 'None'


### PR DESCRIPTION
To avoid "unlock valve" too often, that can lead to resend values from valve to homeassistant. Just unlock it if it was in Outside mode

Closes: #43 