### PR TITLE
Fix: Force new calibration value

### DIFF
--- a/heater_request_compute.yaml
+++ b/heater_request_compute.yaml
@@ -74,7 +74,7 @@ action:
     - service: mqtt.publish
       data:
         topic: "zigbee2mqtt/{{state_attr(local_climate_valve,'friendly_name')}}/set/local_temperature_calibration"
-        payload: "-1.5"
+        payload: "-2.5"
   - conditions:
     - condition: template
       value_template: '{{ states(local_current_temp)|float >= states(local_selected_temp) |float }}'


### PR DESCRIPTION
In order to force the valve to be more opened, we cheat on the calibration value to open the valve despite the valve temperature can be accurate.