### PR TITLE
Fix: Morning daylight should be 100% only after 8:00AM

### DIFF
--- a/light_control.yaml
+++ b/light_control.yaml
@@ -215,7 +215,7 @@ action:
       # before_offset: '-1:00:00'
     - condition: time
       before: '22:00:00'
-      after: '07:00:00'
+      after: '08:00:00'
     - condition: template
       value_template: "{{ not is_bedroom }}"
     sequence:
@@ -250,7 +250,7 @@ action:
       # before_offset: '-1:00:00'
     - condition: time
       after: '22:00:00'
-      before: '07:00:00'
+      before: '08:00:00'
     - condition: template
       value_template: "{{ not is_bedroom }}"
     sequence:


### PR DESCRIPTION
100% should be set only after 8:00, because of winter daylight