### PR TITLE
Fix: Use timer to fix race condition when manual select T°

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ set by automations.
 * Used (RO) : Boolean indicating the room (mostly bedrooms) are subject to automations. If not, T° is always set to Eco
 * Planning (RO) : Planification for switching between Confort (on) and Eco (off) T°
 * Linked (RW) : List (Inside, Outside, Both, None) indicating how room is connected to the house or the outside
+* Selector timer (RW) : Timed selector helper. Wait until manual T° is selected
 
 #### Global helpers
 

--- a/heater_switch_mode.yaml
+++ b/heater_switch_mode.yaml
@@ -29,6 +29,11 @@ blueprint:
       selector:
         entity:
           domain: input_boolean
+    selector_timer:
+      name: Timer to trigger read the temp event
+      selector:
+        entity:
+          domain: timer
 
 mode: queued
 max_exceeded: silent
@@ -37,6 +42,10 @@ variables:
   local_climate_valve: !input climate_valve
 
 trigger:
+- platform: state
+  entity_id: !input trigging_timer
+  to: idle
+  id: TriggeredByTimer
 - platform: state
   entity_id: !input climate_valve
   attribute: temperature
@@ -56,16 +65,25 @@ condition:
 
 action:
 - choose:
+  #### When manual change, wait timer to collect selected T°
   - conditions:
     - condition: state
       entity_id: !input climate_valve
       attribute: preset_mode
       state: manual
     sequence:
-    - service: input_boolean.turn_on
-      data: {}
-      target:
-        entity_id: !input computing_boolean
+      - service: timer.start
+        data:
+          duration: '0:00:03'
+        target:
+          entity_id: !input selector_timer
+
+  #### When timer is Ok, it's time to collect selected T°
+  - conditions:
+    - condition: trigger
+      id:
+        - TriggeredByTimer
+    sequence:
     - service: input_boolean.turn_on
       data: {}
       target:
@@ -74,15 +92,8 @@ action:
       data_template:
         value: "{% set temp = state_attr(local_climate_valve,'temperature')|float %}{{ temp }}"
         entity_id: !input selected_temp
-    - delay:
-        hours: 0
-        minutes: 0
-        seconds: 10
-        milliseconds: 0
-    - service: input_boolean.turn_off
-      data: {}
-      target:
-        entity_id: !input computing_boolean
+
+  #### When auto mode selected, compute T°
   - conditions:
     - condition: state
       entity_id: !input climate_valve


### PR DESCRIPTION
When selecting a setpoint T° on the climate valve, some are sending a MQTT message for each T° crossed during the process. This timer allow to use only the last selected one. Ref: #42 