### PR TITLE
Fix: Remove usage of delays and computing flag, use debouncer

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ set by automations.
 * Setpoint T° (RW) : Climate valve T° range values. Automation can decide the value based on Planning
 * Manual T° (RW) : Boolean indicating that Setpoint is manually determined. Set when climate valve is manually modified
 * Heat (RW) : Boolean indicating that the room need heating
-* Computing (RW) : Boolean avoiding race conditions on starting/setup climate valve
+* Debounce (RW) : Boolean avoiding race conditions on starting/setup climate valve
 * Used (RO) : Boolean indicating the room (mostly bedrooms) are subject to automations. If not, T° is always set to Eco
 * Planning (RO) : Planification for switching between Confort (on) and Eco (off) T°
 * Linked (RW) : List (Inside, Outside, Both, None) indicating how room is connected to the house or the outside

--- a/heater_room_link.yaml
+++ b/heater_room_link.yaml
@@ -41,11 +41,6 @@ blueprint:
       selector:
         entity:
           domain: input_boolean
-    computing_boolean:
-      name: Currently computing setpoint
-      selector:
-        entity:
-          domain: input_boolean
     setpoint_automation:
       name: Setpoint compute automation
       selector:
@@ -64,6 +59,11 @@ blueprint:
         number:
           min: 1
           max: 10
+    debounce_boolean:
+      name: Debounce valve update
+      selector:
+        entity:
+          domain: input_boolean
 
 mode: restart
 max_exceeded: silent
@@ -157,7 +157,7 @@ action:
     - service: input_boolean.turn_on
       data: {}
       target:
-        entity_id: !input computing_boolean
+        entity_id: !input debounce_boolean
     - service: climate.set_temperature
       data_template:
         temperature: '{{ local_freeze_temp }}'
@@ -180,15 +180,6 @@ action:
         option: 'Outside'
       target:
         entity_id: !input room_link_select
-    - delay:
-        hours: 0
-        minutes: 0
-        seconds: 10
-        milliseconds: 0
-    - service: input_boolean.turn_off
-      data: {}
-      target:
-        entity_id: !input computing_boolean
 
   ### Started by timer, inside aperture are open -> unlock and start valve
   - conditions:

--- a/heater_setpoint_compute.yaml
+++ b/heater_setpoint_compute.yaml
@@ -29,11 +29,6 @@ blueprint:
       selector:
         entity:
           domain: input_boolean
-    computing_boolean:
-      name: Currently computing setpoint
-      selector:
-        entity:
-          domain: input_boolean
     setpoint:
       name: Selected °C setpoint
       selector:
@@ -46,6 +41,11 @@ blueprint:
           domain: input_boolean
     occupancy_boolean:
       name: Occupancy
+      selector:
+        entity:
+          domain: input_boolean
+    debounce_boolean:
+      name: Debounce valve update
       selector:
         entity:
           domain: input_boolean
@@ -86,27 +86,18 @@ action:
       entity_id: !input occupancy_boolean
       state: 'off'
     sequence:
-    - service: input_boolean.turn_on
-      data: {}
-      target:
-        entity_id: !input computing_boolean
     - service: input_number.set_value
       data_template:
         value: '{{ states(local_eco_temp) }}'
         entity_id: !input setpoint
+    - service: input_boolean.turn_on
+      data: {}
+      target:
+        entity_id: !input debounce_boolean
     - service: climate.set_temperature
       data_template:
         temperature: '{{ states(local_setpoint) }}'
         entity_id: !input climate_valve
-    - delay:
-        hours: 0
-        minutes: 0
-        seconds: 10
-        milliseconds: 0
-    - service: input_boolean.turn_off
-      data: {}
-      target:
-        entity_id: !input computing_boolean
 
   #
   # When manual, send local setpoint to the valve (used in case of restarting valve for example)
@@ -119,20 +110,11 @@ action:
     - service: input_boolean.turn_on
       data: {}
       target:
-        entity_id: !input computing_boolean
+        entity_id: !input debounce_boolean
     - service: climate.set_temperature
       data_template:
         temperature: '{{ states(local_setpoint) }}'
         entity_id: !input climate_valve
-    - delay:
-        hours: 0
-        minutes: 0
-        seconds: 10
-        milliseconds: 0
-    - service: input_boolean.turn_off
-      data: {}
-      target:
-        entity_id: !input computing_boolean
 
   #
   # When auto, and schedule is on, set comfort t°
@@ -148,27 +130,18 @@ action:
       entity_id: !input occupancy_boolean
       state: 'on'
     sequence:
-    - service: input_boolean.turn_on
-      data: {}
-      target:
-        entity_id: !input computing_boolean
     - service: input_number.set_value
       data_template:
         value: '{{ states(local_comfort_temp) }}'
         entity_id: !input setpoint
+    - service: input_boolean.turn_on
+      data: {}
+      target:
+        entity_id: !input debounce_boolean
     - service: climate.set_temperature
       data_template:
         temperature: '{{ states(local_setpoint) }}'
         entity_id: !input climate_valve
-    - delay:
-        hours: 0
-        minutes: 0
-        seconds: 10
-        milliseconds: 0
-    - service: input_boolean.turn_off
-      data: {}
-      target:
-        entity_id: !input computing_boolean
 
   #
   # When auto, and schedule is off, set eco t°
@@ -181,24 +154,15 @@ action:
       entity_id: !input schedule
       state: 'off'
     sequence:
-    - service: input_boolean.turn_on
-      data: {}
-      target:
-        entity_id: !input computing_boolean
     - service: input_number.set_value
       data_template:
         value: '{{ states(local_eco_temp) }}'
         entity_id: !input setpoint
+    - service: input_boolean.turn_on
+      data: {}
+      target:
+        entity_id: !input debounce_boolean
     - service: climate.set_temperature
       data_template:
         temperature: '{{ states(local_setpoint) }}'
         entity_id: !input climate_valve
-    - delay:
-        hours: 0
-        minutes: 0
-        seconds: 10
-        milliseconds: 0
-    - service: input_boolean.turn_off
-      data: {}
-      target:
-        entity_id: !input computing_boolean

--- a/heater_switch_mode.yaml
+++ b/heater_switch_mode.yaml
@@ -29,6 +29,11 @@ blueprint:
       selector:
         entity:
           domain: timer
+    debounce_boolean:
+      name: Debounce valve update
+      selector:
+        entity:
+          domain: input_boolean
 
 mode: queued
 max_exceeded: silent
@@ -57,7 +62,7 @@ condition:
 action:
 - choose:
 
-  #### When manual change, wait timer to collect selected T°
+  #### When any change, wait timer to collect selected T°
   - conditions:
     - condition: not
       conditions:
@@ -71,7 +76,21 @@ action:
         target:
           entity_id: !input selector_timer
 
-  #### When timer is Ok, it's time to collect selected T°
+  # When debounce is on, just turn off (automated events)
+  - conditions:
+    - condition: trigger
+      id:
+        - TriggeredByTimer
+    - condition: state
+      entity_id: !input debounce_boolean
+      state: 'on'
+    sequence:
+    - service: input_boolean.turn_off
+      data: {}
+      target:
+        entity_id: !input debounce_boolean
+
+  #### When timer is Ok, it's time to collect selected T° and turn flag to manual
   - conditions:
     - condition: trigger
       id:
@@ -90,7 +109,7 @@ action:
         value: "{% set temp = state_attr(local_climate_valve,'temperature')|float %}{{ temp }}"
         entity_id: !input selected_temp
 
-  #### When auto mode selected, compute T°
+  #### When auto mode selected, set debounce and re-send manual to valve
   - conditions:
     - condition: trigger
       id:
@@ -100,6 +119,10 @@ action:
       attribute: preset_mode
       state: auto
     sequence:
+    - service: input_boolean.turn_on
+      data: {}
+      target:
+        entity_id: !input debounce_boolean
     - service: climate.set_preset_mode
       data:
         preset_mode: manual


### PR DESCRIPTION
We now use a flag to indicate debounce status and to make a difference between computed and manual actions.
Ref: #42 