### PR TITLE
Fix: Debounce usage, only when real change made

### DIFF
--- a/heater_room_link.yaml
+++ b/heater_room_link.yaml
@@ -70,7 +70,7 @@ max_exceeded: silent
 
 variables:
   local_freeze_temp: !input freeze_temp_number
-#   local_climate_valve: !input climate_valve
+  local_climate_valve: !input climate_valve
 
 trigger:
 - platform: state
@@ -154,14 +154,18 @@ action:
       entity_id: !input outside_aperture_sensor
       state: 'on'
     sequence:
-    - service: input_boolean.turn_on
-      data: {}
-      target:
-        entity_id: !input debounce_boolean
-    - service: climate.set_temperature
-      data_template:
-        temperature: '{{ local_freeze_temp }}'
-        entity_id: !input climate_valve
+    - if:
+      - condition: template
+        value_template: '{{ state_attr(local_climate_valve, ''temperature'')|float != local_freeze_temp|float }}'
+      then:
+      - service: input_boolean.turn_on
+        data: {}
+        target:
+          entity_id: !input debounce_boolean
+      - service: climate.set_temperature
+        data_template:
+          temperature: '{{ local_freeze_temp }}'
+          entity_id: !input climate_valve
     - service: climate.turn_off
       data: {}
       target:

--- a/heater_setpoint_compute.yaml
+++ b/heater_setpoint_compute.yaml
@@ -57,6 +57,7 @@ variables:
   local_comfort_temp: !input comfort_temp
   local_eco_temp: !input eco_temp
   local_setpoint: !input setpoint
+  local_climate_valve: !input climate_valve
 
 trigger:
 - platform: state
@@ -90,14 +91,18 @@ action:
       data_template:
         value: '{{ states(local_eco_temp) }}'
         entity_id: !input setpoint
-    - service: input_boolean.turn_on
-      data: {}
-      target:
-        entity_id: !input debounce_boolean
-    - service: climate.set_temperature
-      data_template:
-        temperature: '{{ states(local_setpoint) }}'
-        entity_id: !input climate_valve
+    - if:
+      - condition: template
+        value_template: '{{ state_attr(local_climate_valve, ''temperature'')|float != states(local_setpoint)|float }}'
+      then:
+      - service: input_boolean.turn_on
+        data: {}
+        target:
+          entity_id: !input debounce_boolean
+      - service: climate.set_temperature
+        data_template:
+          temperature: '{{ states(local_setpoint) }}'
+          entity_id: !input climate_valve
 
   #
   # When manual, send local setpoint to the valve (used in case of restarting valve for example)
@@ -107,14 +112,18 @@ action:
       entity_id: !input manual_boolean
       state: 'on'
     sequence:
-    - service: input_boolean.turn_on
-      data: {}
-      target:
-        entity_id: !input debounce_boolean
-    - service: climate.set_temperature
-      data_template:
-        temperature: '{{ states(local_setpoint) }}'
-        entity_id: !input climate_valve
+    - if:
+      - condition: template
+        value_template: '{{ state_attr(local_climate_valve, ''temperature'')|float != states(local_setpoint)|float }}'
+      then:
+      - service: input_boolean.turn_on
+        data: {}
+        target:
+          entity_id: !input debounce_boolean
+      - service: climate.set_temperature
+        data_template:
+          temperature: '{{ states(local_setpoint) }}'
+          entity_id: !input climate_valve
 
   #
   # When auto, and schedule is on, set comfort t°
@@ -134,14 +143,18 @@ action:
       data_template:
         value: '{{ states(local_comfort_temp) }}'
         entity_id: !input setpoint
-    - service: input_boolean.turn_on
-      data: {}
-      target:
-        entity_id: !input debounce_boolean
-    - service: climate.set_temperature
-      data_template:
-        temperature: '{{ states(local_setpoint) }}'
-        entity_id: !input climate_valve
+    - if:
+      - condition: template
+        value_template: '{{ state_attr(local_climate_valve, ''temperature'')|float != states(local_setpoint)|float }}'
+      then:
+      - service: input_boolean.turn_on
+        data: {}
+        target:
+          entity_id: !input debounce_boolean
+      - service: climate.set_temperature
+        data_template:
+          temperature: '{{ states(local_setpoint) }}'
+          entity_id: !input climate_valve
 
   #
   # When auto, and schedule is off, set eco t°
@@ -158,11 +171,15 @@ action:
       data_template:
         value: '{{ states(local_eco_temp) }}'
         entity_id: !input setpoint
-    - service: input_boolean.turn_on
-      data: {}
-      target:
-        entity_id: !input debounce_boolean
-    - service: climate.set_temperature
-      data_template:
-        temperature: '{{ states(local_setpoint) }}'
-        entity_id: !input climate_valve
+    - if:
+      - condition: template
+        value_template: '{{ state_attr(local_climate_valve, ''temperature'')|float != states(local_setpoint)|float }}'
+      then:
+      - service: input_boolean.turn_on
+        data: {}
+        target:
+          entity_id: !input debounce_boolean
+      - service: climate.set_temperature
+        data_template:
+          temperature: '{{ states(local_setpoint) }}'
+          entity_id: !input climate_valve


### PR DESCRIPTION
The bounce message from the valve only arrives when value is changed, so we must check before setting debounce flag (and sendin value)
Ref: #69 