### PR TITLE
Fix: Use "state:" instead of "to:" keyword on condition

### DIFF
--- a/heater_boot_management.yaml
+++ b/heater_boot_management.yaml
@@ -47,7 +47,7 @@ action:
         - TriggeredByTimer
     - condition: state
       entity_id: !input trigging_timer
-      to: active
+      state: active
     sequence:
     - service: automation.turn_off
       data:
@@ -62,7 +62,7 @@ action:
         - TriggeredByTimer
     - condition: state
       entity_id: !input trigging_timer
-      to: idle
+      state: idle
     sequence:
     - service: automation.turn_on
       data: {}


### PR DESCRIPTION
Misuse of the "to:" keyword
Ref: #72 