### PR TITLE
Fix: Set queued mode run

### DIFF
--- a/heater_boot_management.yaml
+++ b/heater_boot_management.yaml
@@ -16,7 +16,7 @@ blueprint:
           domain: automation
           multiple: true
 
-mode: single
+mode: queued
 max_exceeded: silent
 
 trigger:


### PR DESCRIPTION
Timer start will trigger a second run of automation, we can queue it
Ref: #72 