### PR TITLE
Fix: Change 'regulated' to 'active' for best meaning

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ set by automations.
 * Planning (RO) : Planification for switching between Confort (on) and Eco (off) T°
 * Linked (RW) : List (Inside, Outside, Both, None) indicating how room is connected to the house or the outside
 * Selector timer (RW) : Timed selector helper. Wait until manual T° is selected
-* Regulated (RO) : Boolean indicating the room are able to request heating. If off, no heat can be request, only valve changes allowed.
+* Active (RO) : Boolean indicating the room is able to request heating. If off, no heat can be request, only valve changes allowed.
 
 #### Global helpers
 

--- a/heater_request_compute.yaml
+++ b/heater_request_compute.yaml
@@ -34,8 +34,8 @@ blueprint:
       selector:
         entity:
           domain: input_select
-    regulated_boolean:
-      name: Regulated by automation
+    active_boolean:
+      name: Active for automation
       selector:
         entity:
           domain: input_boolean
@@ -65,7 +65,7 @@ condition:
     entity_id: !input winter_mode_boolean
     state: 'on'
   - condition: state
-    entity_id: !input regulated_boolean
+    entity_id: !input active_boolean
     state: 'on'
   - or:
       - condition: state


### PR DESCRIPTION
Old name was not really clear.