### PR TITLE
Fix: Stop override timer when mode is changed

### DIFF
--- a/heater_switch_mode.yaml
+++ b/heater_switch_mode.yaml
@@ -197,6 +197,10 @@ action:
       data: {}
       target:
         entity_id: !input occupancy_boolean
+    - service: timer.cancel
+      data: {}
+      target:
+        entity_id: !input override_timer
 
   #### When holiday mode selected, set debounce and re-send manual to valve
   - conditions:
@@ -221,3 +225,7 @@ action:
       data: {}
       target:
         entity_id: !input occupancy_boolean
+    - service: timer.cancel
+      data: {}
+      target:
+        entity_id: !input override_timer


### PR DESCRIPTION
If setpoint is not modified, but mode is changer, cancel the override timer. It should only be used when T° is modified to manual.