### PR TITLE
Fix: Set debounce when modifying valve preset

### DIFF
--- a/heater_switch_mode.yaml
+++ b/heater_switch_mode.yaml
@@ -134,6 +134,10 @@ action:
       data: {}
       target:
         entity_id: !input manual_boolean
+    - service: input_boolean.turn_on
+      data: {}
+      target:
+        entity_id: !input debounce_boolean
     - service: climate.set_preset_mode
       data:
         preset_mode: auto


### PR DESCRIPTION
When reset the TRV to automated functions, need to setup debounce flag because it's not a human change