### PR TITLE
Fix: Syntax/usage error on triggering conditions

### DIFF
--- a/heater_switch_mode.yaml
+++ b/heater_switch_mode.yaml
@@ -94,11 +94,13 @@ action:
   - conditions:
     - condition: not
       conditions:
-        - condition: trigger
-          id:
-            - TriggeredByTimer
-            - TriggeredByOverrideReset
-          match: any
+        - or:
+          - condition: trigger
+            id:
+              - TriggeredByTimer
+          - condition: trigger
+            id:
+              - TriggeredByOverrideReset
     sequence:
       - service: timer.start
         data:


### PR DESCRIPTION
Don't use multiple id's when trigger condition is called. Use or: instead of using match:any